### PR TITLE
Version2.4: Add additional filestring param for parse.Parser init method.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='pyhaproxy',
-    version='0.2.2',
+    version='0.2.4',
     keywords=('haproxy', 'parse'),
     description='A Python library to parse haproxy configuration file',
     license='MIT License',


### PR DESCRIPTION
Move version 2.4, package has been uploaded to pypi.

Release Notes v2.4:

- Add `filestring` as the second parameter of parse.Parser init method.
- The unit test could run anywhere, for the newly added `filestring` param.