### PR TITLE
Remove the py3 incompatible print clauses

### DIFF
--- a/pyhaproxy/pegnode.py
+++ b/pyhaproxy/pegnode.py
@@ -3109,11 +3109,3 @@ def format_error(input, offset, expected):
 def parse(input, actions=None, types=None):
     parser = Parser(input, actions, types)
     return parser.parse()
-
-
-if __name__ == '__main__':
-    with open('haproxy.cfg') as f:
-        filestring = f.read()
-        tree = parse(filestring)
-        for ele in tree.elements:
-            print ele.offset, ele.text

--- a/pyhaproxy/render.py
+++ b/pyhaproxy/render.py
@@ -39,7 +39,6 @@ class Render(object):
     def dumps_to(self, filepath):
         with open(filepath, 'w') as f:
             f.write(self.render_configuration())
-        print 'write configs into %s succeed' % filepath
 
     def render_global(self, globall):
         globall_str = '''


### PR DESCRIPTION
Fixes #17 . The `print` clauses are useless. So removing them is the simplest. I will consider to make the library be compatible with both PY2 and PY3 in future development.