### PR TITLE
Bugfix: failed to render listen blocks

### DIFF
--- a/pyhaproxy/render.py
+++ b/pyhaproxy/render.py
@@ -72,7 +72,7 @@ listen %s %s
 %s
 '''
         host_port = ''
-        if not bool(listen.config_block['binds']):
+        if not len(listen.binds()):
             host_port = '%s:%s' % (listen.host, listen.port)
 
         return listen_str % (
@@ -85,7 +85,7 @@ frontend %s %s
 %s
 '''
         host_port = ''
-        if len(frontend.binds()) == 0:
+        if not len(frontend.binds()):
             host_port = '%s:%s' % (frontend.host, frontend.port)
 
         return frontend_str % (


### PR DESCRIPTION
Fixes #20 . Use `listen.bind()` to retrieve the `bind` configuration lines, instead of the outdated `listen.config_block['binds']` after commit 510d9d9b63ef93cf7a000a5daa5086c39ff4cd04 .