### PR TITLE
Explicitly use python 2.7 in Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-language: python
+language: python:2.7
 
 before_install:
   - sudo apt-get -y install python-pip


### PR DESCRIPTION
As Python 3.6 has been becoming the default since April 16th, 2019, explicitly set Python to 2.7 in Travis CI.

Signed-off-by: imjoey <majunjiev@gmail.com>